### PR TITLE
Fix branch name validation to support Estonian characters (äöõü, ÄÖÕÜ)

### DIFF
--- a/.github/workflows/branch_name_check.yml
+++ b/.github/workflows/branch_name_check.yml
@@ -15,8 +15,8 @@ jobs:
           BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
           echo "Current branch: $BRANCH_NAME"
 
-          if [[ ! "$BRANCH_NAME" =~ ^[0-9]+_[a-z0-9_]+$ ]]; then
+          if [[ ! "$BRANCH_NAME" =~ ^[0-9]+_[a-z0-9_äöõü]+$ ]]; then
             echo "❌ Haru nimi peab olema kujul: number_snake_case_nimi"
-            echo "Näide: 42_edit_assignment_criteria"
+            echo "Näide: 42_edit_assignment_criteria või 16_learning_outcomes_õv"
             exit 1
           fi

--- a/.github/workflows/branch_name_check.yml
+++ b/.github/workflows/branch_name_check.yml
@@ -15,8 +15,8 @@ jobs:
           BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
           echo "Current branch: $BRANCH_NAME"
 
-          if [[ ! "$BRANCH_NAME" =~ ^[0-9]+_[a-z0-9_äöõü]+$ ]]; then
+          if [[ ! "$BRANCH_NAME" =~ ^[0-9]+_[a-zA-Z0-9_äöõüÄÖÕÜ]+$ ]]; then
             echo "❌ Haru nimi peab olema kujul: number_snake_case_nimi"
-            echo "Näide: 42_edit_assignment_criteria või 16_learning_outcomes_õv"
+            echo "Näide: 42_edit_assignment_criteria või 16_learning_outcomes_õv või 23_TÜ_Õppekava"
             exit 1
           fi


### PR DESCRIPTION
This PR fixes issue #18 by updating the branch name validation regex to support Estonian characters.

## Changes:
- Updated regex pattern from \`^[0-9]+_[a-z0-9_äöõü]+$\` to \`^[0-9]+_[a-zA-Z0-9_äöõüÄÖÕÜ]+$\`
- Added support for both lowercase and uppercase Estonian characters (äöõü, ÄÖÕÜ)
- Updated example in error message to show Estonian characters are supported

## Testing:
- Branch name \`16_as_a_teacher_i_want_assignments_tagged_with_learning_outcomes_õv_to_be_created_and_visible_in_my_journal\` will now pass validation
- Names like \`23_TÜ_Õppekava\` are now also supported

Fixes #18